### PR TITLE
VCR ignores HTTP headers so no more calls needed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
     parser (2.4.0.0)
       ast (~> 2.2)
     path_expander (1.0.2)
+    pg (0.21.0)
     powerpack (0.1.1)
     pry (0.11.2)
       coderay (~> 1.1.0)
@@ -176,6 +177,7 @@ DEPENDENCIES
   minitest
   minitest-rg
   multi_json
+  pg
   pry
   puma
   rack-test

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -9,7 +9,7 @@ describe 'Tests MOTC API library' do
   before do
     VCR.insert_cassette CASSETTE_FILE,
                         record: :new_episodes,
-                        match_requests_on: %i[method uri headers]
+                        match_requests_on: %i[method uri]
   end
 
   after do

--- a/spec/city_stop_spec.rb
+++ b/spec/city_stop_spec.rb
@@ -15,7 +15,7 @@ describe 'Tests Bus Stop library' do
   before do
     VCR.insert_cassette CASSETTE_FILE,
                         record: :new_episodes,
-                        match_requests_on: %i[method uri headers]
+                        match_requests_on: %i[method uri]
   end
 
   after do

--- a/spec/route_stop_spec.rb
+++ b/spec/route_stop_spec.rb
@@ -15,7 +15,7 @@ describe 'Tests Bus Stop library' do
   before do
     VCR.insert_cassette CASSETTE_FILE,
                         record: :new_episodes,
-                        match_requests_on: %i[method uri headers]
+                        match_requests_on: %i[method uri]
   end
 
   after do

--- a/spec/stops_of_route_spec.rb
+++ b/spec/stops_of_route_spec.rb
@@ -15,7 +15,7 @@ describe 'Tests Stops of route' do
   before do
     VCR.insert_cassette CASSETTE_FILE,
                         record: :new_episodes,
-                        match_requests_on: %i[method uri headers]
+                        match_requests_on: %i[method uri]
   end
 
   after do


### PR DESCRIPTION
Just removed `headers` from VCR configuration